### PR TITLE
fix: MarkdownPreview prints Node.js v22.x.x and does nothing

### DIFF
--- a/.config/nvim/lua/plugins/coding/markdown/markdown-preview.lua
+++ b/.config/nvim/lua/plugins/coding/markdown/markdown-preview.lua
@@ -3,9 +3,13 @@ local md_filetypes = require("util").md_filetypes
 return {
   "iamcco/markdown-preview.nvim",
   lazy = true,
+  -- @see: ~/.local/state/nvim/lazy/readme/doc/markdown-preview.nvim.md
+  -- @see: https://github.com/iamcco/markdown-preview.nvim/issues/695
+  build = "cd app && yarn install",
   cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
   ft = md_filetypes,
   init = function()
+    vim.g.mkdp_filetypes = { "markdown" }
     vim.g.mkdp_theme = "light"
     vim.g.mkdp_preview_options = {
       disable_filename = 1,


### PR DESCRIPTION
## Changes
<!-- Briefly describe what you've changed -->

- 8c0678b 2025-11-05 07:27:43 k.takimoto fix: MarkdownPreview prints Node.js v22.x.x and does nothing

## Verification
<!-- Describe how you verified the changes and their effects -->

`:MarkdownPreview`

## Related Issue
<!-- enter issue number -->
close #302

## Notes
<!-- Any additional information, references, or future tasks -->
