### PR TITLE
set keymaps for moving between first and last tab

### DIFF
--- a/.config/nvim/lua/config/keymaps.lua
+++ b/.config/nvim/lua/config/keymaps.lua
@@ -27,6 +27,10 @@ km.nmap("<leader>ut", function()
   vim.opt.list = not vim.opt.list:get()
 end, { desc = "[t]oggle listchars visibility" })
 
+-- [[ Tab ]]
+km.nmap("1gt", ":tabfirst<CR>", { desc = "Go to first tab" }) -- Go to the first tab
+km.nmap("9gt", ":tablast<CR>", { desc = "Go to last tab" }) -- Go to the last tab
+
 -- [[ File Path ]]
 km.nmap("<leader>p", ":let @+ = expand('%')<CR>", { desc = "Copy file path" })
 


### PR DESCRIPTION
## Changes
<!-- Briefly describe what you've changed -->

- set keymaps such as `1gt` and `9gt`

## Verification
<!-- Describe how you verified the changes and their effects -->

- use the keymaps in normal mode

## Related Issue
<!-- enter issue number -->
close #316

## Notes
<!-- Any additional information, references, or future tasks -->
